### PR TITLE
Add SnipFeedAI demo app

### DIFF
--- a/SnipFeedAI/README.md
+++ b/SnipFeedAI/README.md
@@ -1,0 +1,23 @@
+# SnipFeedAI
+
+SnipFeedAI is a lightweight demo that generates bite-sized, AI-powered knowledge feeds. A user enters a topic, and the backend uses a free, open-source text generation model to build a five item feed:
+
+1. 💡 Concept
+2. 🧠 Analogy
+3. ✍️ Quote
+4. 🎯 Challenge
+5. 🤖 Fun Fact
+
+The frontend is a minimalist Tailwind page, and the backend is a small FastAPI service.
+
+## Structure
+- `backend/app.py` – FastAPI server exposing a `/generate` endpoint
+- `backend/requirements.txt` – Python dependencies
+- `frontend/index.html` – simple UI that calls the backend
+
+## Run locally
+```bash
+pip install -r SnipFeedAI/backend/requirements.txt
+uvicorn SnipFeedAI.backend.app:app --reload
+# open frontend/index.html in a browser
+```

--- a/SnipFeedAI/backend/app.py
+++ b/SnipFeedAI/backend/app.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from transformers import pipeline
+
+app = FastAPI()
+
+# use a small, freely available model
+generator = pipeline("text-generation", model="distilgpt2")
+
+PROMPT_TEMPLATE = """
+You are a fun, smart educator. Give a 5-part microlearning feed on the topic: '{topic}'.
+
+Structure your output as:
+1. 💡 Concept: Explain the topic in a simple way
+2. 🧠 Analogy: Use a vivid analogy or metaphor
+3. ✍️ Quote: A real or generated quote on the topic
+4. 🎯 Challenge: A 1-day mini action user can take to apply it
+5. 🤖 Fun Fact: Something surprising, meme-worthy, or trivia-like
+
+Keep each section short and easy to read. Use modern, friendly tone.
+"""
+
+class Topic(BaseModel):
+    topic: str
+
+@app.post("/generate")
+async def generate_feed(topic: Topic):
+    prompt = PROMPT_TEMPLATE.format(topic=topic.topic)
+    result = generator(prompt, max_length=400, num_return_sequences=1)[0]["generated_text"]
+    return {"feed": result}

--- a/SnipFeedAI/backend/requirements.txt
+++ b/SnipFeedAI/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+transformers

--- a/SnipFeedAI/frontend/index.html
+++ b/SnipFeedAI/frontend/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>SnipFeedAI</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-r from-purple-400 via-pink-500 to-red-500 min-h-screen flex items-center justify-center">
+  <div class="bg-white bg-opacity-60 p-6 rounded-2xl shadow-xl max-w-md w-full backdrop-blur">
+    <h1 class="text-2xl font-bold mb-4 text-center">SnipFeedAI</h1>
+    <input id="topic" class="w-full p-2 mb-3 rounded" placeholder="Enter a topic" />
+    <button id="generate" class="w-full bg-blue-500 text-white py-2 rounded">Generate</button>
+    <pre id="output" class="mt-4 whitespace-pre-wrap"></pre>
+  </div>
+  <script>
+    document.getElementById('generate').addEventListener('click', async () => {
+      const topic = document.getElementById('topic').value;
+      const res = await fetch('/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic })
+      });
+      const data = await res.json();
+      document.getElementById('output').textContent = data.feed || 'No result';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold SnipFeedAI demo with FastAPI backend and Tailwind frontend
- include README and requirements for running demo
- remove compiled bytecode

## Testing
- `python -m py_compile SnipFeedAI/backend/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68973f31b7e483319110357679a2248e